### PR TITLE
Contrain article images to parent container width

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -219,6 +219,11 @@ nav.sections a {
     color: var(--accent);
 }
 
+.article-content img {
+    max-width: 100%;
+    height: auto;
+}
+
 .article-content h2 {
     font-family: var(--font-serif);
     font-size: 2rem;


### PR DESCRIPTION
Here's current vs new images to compare!

# Current

<img width="1145" height="952" alt="Screenshot 2025-12-08 at 2 15 53 AM" src="https://github.com/user-attachments/assets/9e1b67d0-d701-4535-9259-4e89c39967f7" />


# After PR

<img width="1029" height="877" alt="Screenshot 2025-12-08 at 2 13 58 AM" src="https://github.com/user-attachments/assets/cfd973fb-bcb3-4910-9eaa-b326b5b7440b" />
